### PR TITLE
escape dynamic path parameters with url.PathEscape

### DIFF
--- a/sdk/api/accounts.go
+++ b/sdk/api/accounts.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewAccountsAPI(http *http.Client, workspaceID string) *AccountsAPI {
 }
 
 func (api *AccountsAPI) GetAccounts(ctx context.Context, query ...*types.AccountsQuery) (*types.Accounts, error) {
-	path := fmt.Sprintf("/workspaces/%s/accounts", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/accounts", url.PathEscape(api.workspaceID))
 	var result types.Accounts
 	var queryParam *types.AccountsQuery
 	if len(query) > 0 && query[0] != nil {
@@ -37,7 +38,7 @@ func (api *AccountsAPI) GetAccounts(ctx context.Context, query ...*types.Account
 }
 
 func (api *AccountsAPI) GetAccountByID(ctx context.Context, accountId string) (*types.Account, error) {
-	path := fmt.Sprintf("/workspaces/%s/accounts/%s", api.workspaceID, accountId)
+	path := fmt.Sprintf("/workspaces/%s/accounts/%s", url.PathEscape(api.workspaceID), url.PathEscape(accountId))
 	var result types.Account
 	options := http.RequestOptions{
 		Method: "GET",

--- a/sdk/api/addressBook.go
+++ b/sdk/api/addressBook.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewAddressBookAPI(http *http.Client, workspaceID string) *AddressBookAPI {
 }
 
 func (api *AddressBookAPI) GetAddressBookRecords(ctx context.Context, query ...*types.AddressBookRecordsQuery) (*types.AddressBookRecords, error) {
-	path := fmt.Sprintf("/workspaces/%s/address-book-records", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/address-book-records", url.PathEscape(api.workspaceID))
 	var result types.AddressBookRecords
 	var queryParam *types.AddressBookRecordsQuery
 	if len(query) > 0 && query[0] != nil {
@@ -37,7 +38,7 @@ func (api *AddressBookAPI) GetAddressBookRecords(ctx context.Context, query ...*
 }
 
 func (api *AddressBookAPI) CreateAddressBookRecord(ctx context.Context, body types.CreateAddressBookRecord) (*types.AddressBookRecord, error) {
-	path := fmt.Sprintf("/workspaces/%s/address-book-records", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/address-book-records", url.PathEscape(api.workspaceID))
 	var result types.AddressBookRecord
 	options := http.RequestOptions{
 		Method: "POST",
@@ -49,7 +50,7 @@ func (api *AddressBookAPI) CreateAddressBookRecord(ctx context.Context, body typ
 }
 
 func (api *AddressBookAPI) DeactivateAddressBookRecord(ctx context.Context, recordId string) (*types.Unit, error) {
-	path := fmt.Sprintf("/workspaces/%s/address-book-records/%s", api.workspaceID, recordId)
+	path := fmt.Sprintf("/workspaces/%s/address-book-records/%s", url.PathEscape(api.workspaceID), url.PathEscape(recordId))
 	var result types.Unit
 	options := http.RequestOptions{
 		Method: "DELETE",
@@ -60,7 +61,7 @@ func (api *AddressBookAPI) DeactivateAddressBookRecord(ctx context.Context, reco
 }
 
 func (api *AddressBookAPI) GetAddressBookRecordByID(ctx context.Context, recordId string) (*types.AddressBookRecord, error) {
-	path := fmt.Sprintf("/workspaces/%s/address-book-records/%s", api.workspaceID, recordId)
+	path := fmt.Sprintf("/workspaces/%s/address-book-records/%s", url.PathEscape(api.workspaceID), url.PathEscape(recordId))
 	var result types.AddressBookRecord
 	options := http.RequestOptions{
 		Method: "GET",

--- a/sdk/api/addresses.go
+++ b/sdk/api/addresses.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewAddressesAPI(http *http.Client, workspaceID string) *AddressesAPI {
 }
 
 func (api *AddressesAPI) GetDepositAddresses(ctx context.Context, query ...*types.DepositAddressesQuery) (*types.Addresses, error) {
-	path := fmt.Sprintf("/workspaces/%s/addresses", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/addresses", url.PathEscape(api.workspaceID))
 	var result types.Addresses
 	var queryParam *types.DepositAddressesQuery
 	if len(query) > 0 && query[0] != nil {

--- a/sdk/api/assets.go
+++ b/sdk/api/assets.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -48,7 +49,7 @@ func (api *AssetsAPI) GetAssets(ctx context.Context, query ...*types.AssetsQuery
 }
 
 func (api *AssetsAPI) GetAssetByID(ctx context.Context, assetId string, query ...*types.AssetByIDQuery) (*types.Asset, error) {
-	path := fmt.Sprintf("/dictionary/assets/%s", assetId)
+	path := fmt.Sprintf("/dictionary/assets/%s", url.PathEscape(assetId))
 	var result types.Asset
 	var queryParam *types.AssetByIDQuery
 	if len(query) > 0 && query[0] != nil {
@@ -80,7 +81,7 @@ func (api *AssetsAPI) GetNetworks(ctx context.Context, query ...*types.NetworksQ
 }
 
 func (api *AssetsAPI) GetNetworkByID(ctx context.Context, networkId string) (*types.Network, error) {
-	path := fmt.Sprintf("/dictionary/networks/%s", networkId)
+	path := fmt.Sprintf("/dictionary/networks/%s", url.PathEscape(networkId))
 	var result types.Network
 	options := http.RequestOptions{
 		Method: "GET",
@@ -123,7 +124,7 @@ func (api *AssetsAPI) GetSymbols(ctx context.Context, query ...*types.SymbolsQue
 }
 
 func (api *AssetsAPI) GetSymbolByID(ctx context.Context, symbolId string, query ...*types.SymbolByIDQuery) (*types.Symbol, error) {
-	path := fmt.Sprintf("/dictionary/symbols/%s", symbolId)
+	path := fmt.Sprintf("/dictionary/symbols/%s", url.PathEscape(symbolId))
 	var result types.Symbol
 	var queryParam *types.SymbolByIDQuery
 	if len(query) > 0 && query[0] != nil {

--- a/sdk/api/balances.go
+++ b/sdk/api/balances.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewBalancesAPI(http *http.Client, workspaceID string) *BalancesAPI {
 }
 
 func (api *BalancesAPI) GetBalances(ctx context.Context, query ...*types.BalancesQuery) (*types.Balances, error) {
-	path := fmt.Sprintf("/workspaces/%s/balances", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/balances", url.PathEscape(api.workspaceID))
 	var result types.Balances
 	var queryParam *types.BalancesQuery
 	if len(query) > 0 && query[0] != nil {
@@ -37,7 +38,7 @@ func (api *BalancesAPI) GetBalances(ctx context.Context, query ...*types.Balance
 }
 
 func (api *BalancesAPI) GetBalanceByID(ctx context.Context, balanceId string) (*types.Balance, error) {
-	path := fmt.Sprintf("/workspaces/%s/balances/%s", api.workspaceID, balanceId)
+	path := fmt.Sprintf("/workspaces/%s/balances/%s", url.PathEscape(api.workspaceID), url.PathEscape(balanceId))
 	var result types.Balance
 	options := http.RequestOptions{
 		Method: "GET",

--- a/sdk/api/intents.go
+++ b/sdk/api/intents.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewIntentsAPI(http *http.Client, workspaceID string) *IntentsAPI {
 }
 
 func (api *IntentsAPI) CreateIntentRequest(ctx context.Context, body types.CreateIntent) (*types.Intent, error) {
-	path := fmt.Sprintf("/workspaces/%s/intents", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/intents", url.PathEscape(api.workspaceID))
 	var result types.Intent
 	options := http.RequestOptions{
 		Method: "POST",
@@ -33,7 +34,7 @@ func (api *IntentsAPI) CreateIntentRequest(ctx context.Context, body types.Creat
 }
 
 func (api *IntentsAPI) GetIntentRequestByID(ctx context.Context, intentId string) (*types.Intent, error) {
-	path := fmt.Sprintf("/workspaces/%s/intents/%s", api.workspaceID, intentId)
+	path := fmt.Sprintf("/workspaces/%s/intents/%s", url.PathEscape(api.workspaceID), url.PathEscape(intentId))
 	var result types.Intent
 	options := http.RequestOptions{
 		Method: "GET",

--- a/sdk/api/stake.go
+++ b/sdk/api/stake.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewStakeAPI(http *http.Client, workspaceID string) *StakeAPI {
 }
 
 func (api *StakeAPI) GetStakes(ctx context.Context, query ...*types.StakesQuery) (*types.Stakes, error) {
-	path := fmt.Sprintf("/workspaces/%s/stakes", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/stakes", url.PathEscape(api.workspaceID))
 	var result types.Stakes
 	var queryParam *types.StakesQuery
 	if len(query) > 0 && query[0] != nil {

--- a/sdk/api/transactionLimits.go
+++ b/sdk/api/transactionLimits.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewTransactionLimitsAPI(http *http.Client, workspaceID string) *Transaction
 }
 
 func (api *TransactionLimitsAPI) GetTransactionLimits(ctx context.Context, query ...*types.TransactionLimitsQuery) (*types.TransactionLimits, error) {
-	path := fmt.Sprintf("/workspaces/%s/transaction-limits", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/transaction-limits", url.PathEscape(api.workspaceID))
 	var result types.TransactionLimits
 	var queryParam *types.TransactionLimitsQuery
 	if len(query) > 0 && query[0] != nil {
@@ -37,7 +38,7 @@ func (api *TransactionLimitsAPI) GetTransactionLimits(ctx context.Context, query
 }
 
 func (api *TransactionLimitsAPI) GetTransactionLimitByID(ctx context.Context, limitId string) (*types.TransactionLimit, error) {
-	path := fmt.Sprintf("/workspaces/%s/transaction-limits/%s", api.workspaceID, limitId)
+	path := fmt.Sprintf("/workspaces/%s/transaction-limits/%s", url.PathEscape(api.workspaceID), url.PathEscape(limitId))
 	var result types.TransactionLimit
 	options := http.RequestOptions{
 		Method: "GET",

--- a/sdk/api/transactions.go
+++ b/sdk/api/transactions.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewTransactionsAPI(http *http.Client, workspaceID string) *TransactionsAPI 
 }
 
 func (api *TransactionsAPI) GetTransactions(ctx context.Context, query ...*types.TransactionsQuery) (*types.Transactions, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/transactions", url.PathEscape(api.workspaceID))
 	var result types.Transactions
 	var queryParam *types.TransactionsQuery
 	if len(query) > 0 && query[0] != nil {
@@ -37,7 +38,7 @@ func (api *TransactionsAPI) GetTransactions(ctx context.Context, query ...*types
 }
 
 func (api *TransactionsAPI) CreateTransaction(ctx context.Context, body types.CreateTransaction) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/transactions", url.PathEscape(api.workspaceID))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -49,7 +50,7 @@ func (api *TransactionsAPI) CreateTransaction(ctx context.Context, body types.Cr
 }
 
 func (api *TransactionsAPI) CreateMultipleTransactions(ctx context.Context, body types.CreateTransactions) (*types.Transactions, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/bulk-create", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/transactions/bulk-create", url.PathEscape(api.workspaceID))
 	var result types.Transactions
 	options := http.RequestOptions{
 		Method: "POST",
@@ -61,7 +62,7 @@ func (api *TransactionsAPI) CreateMultipleTransactions(ctx context.Context, body
 }
 
 func (api *TransactionsAPI) DryRunTransaction(ctx context.Context, body types.CreateTransaction) (*types.DryRunTransaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/dry-run", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/transactions/dry-run", url.PathEscape(api.workspaceID))
 	var result types.DryRunTransaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -73,7 +74,7 @@ func (api *TransactionsAPI) DryRunTransaction(ctx context.Context, body types.Cr
 }
 
 func (api *TransactionsAPI) GetTransactionByID(ctx context.Context, transactionId string) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "GET",
@@ -84,7 +85,7 @@ func (api *TransactionsAPI) GetTransactionByID(ctx context.Context, transactionI
 }
 
 func (api *TransactionsAPI) AcceptDepositOffer(ctx context.Context, transactionId string, body types.OfferActions) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/accept-deposit-offer", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/accept-deposit-offer", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -96,7 +97,7 @@ func (api *TransactionsAPI) AcceptDepositOffer(ctx context.Context, transactionI
 }
 
 func (api *TransactionsAPI) ApproveTransaction(ctx context.Context, transactionId string, body types.ApproveTransaction) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/approve", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/approve", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -108,7 +109,7 @@ func (api *TransactionsAPI) ApproveTransaction(ctx context.Context, transactionI
 }
 
 func (api *TransactionsAPI) CancelTransaction(ctx context.Context, transactionId string, body types.CancelTransaction) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/cancel", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/cancel", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -120,7 +121,7 @@ func (api *TransactionsAPI) CancelTransaction(ctx context.Context, transactionId
 }
 
 func (api *TransactionsAPI) CreateSigningRequest(ctx context.Context, transactionId string) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/create-signing-request", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/create-signing-request", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -131,7 +132,7 @@ func (api *TransactionsAPI) CreateSigningRequest(ctx context.Context, transactio
 }
 
 func (api *TransactionsAPI) DeclineTransaction(ctx context.Context, transactionId string, body types.CancelTransaction) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/decline", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/decline", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",
@@ -143,7 +144,7 @@ func (api *TransactionsAPI) DeclineTransaction(ctx context.Context, transactionI
 }
 
 func (api *TransactionsAPI) GetTransactionEvents(ctx context.Context, transactionId string) (*types.TransactionEvents, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/events", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/events", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.TransactionEvents
 	options := http.RequestOptions{
 		Method: "GET",
@@ -154,7 +155,7 @@ func (api *TransactionsAPI) GetTransactionEvents(ctx context.Context, transactio
 }
 
 func (api *TransactionsAPI) RejectOutgoingOffer(ctx context.Context, transactionId string, body types.OfferActions) (*types.Transaction, error) {
-	path := fmt.Sprintf("/workspaces/%s/transactions/%s/reject-outgoing-offer", api.workspaceID, transactionId)
+	path := fmt.Sprintf("/workspaces/%s/transactions/%s/reject-outgoing-offer", url.PathEscape(api.workspaceID), url.PathEscape(transactionId))
 	var result types.Transaction
 	options := http.RequestOptions{
 		Method: "POST",

--- a/sdk/api/workspaces.go
+++ b/sdk/api/workspaces.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"context"
 	"github.com/bronlabs/bron-sdk-go/sdk/http"
@@ -21,7 +22,7 @@ func NewWorkspacesAPI(http *http.Client, workspaceID string) *WorkspacesAPI {
 }
 
 func (api *WorkspacesAPI) GetWorkspaceByID(ctx context.Context, query ...*types.WorkspaceByIDQuery) (*types.Workspace, error) {
-	path := fmt.Sprintf("/workspaces/%s", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s", url.PathEscape(api.workspaceID))
 	var result types.Workspace
 	var queryParam *types.WorkspaceByIDQuery
 	if len(query) > 0 && query[0] != nil {
@@ -37,7 +38,7 @@ func (api *WorkspacesAPI) GetWorkspaceByID(ctx context.Context, query ...*types.
 }
 
 func (api *WorkspacesAPI) GetActivities(ctx context.Context, query ...*types.ActivitiesQuery) (*types.Activities, error) {
-	path := fmt.Sprintf("/workspaces/%s/activities", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/activities", url.PathEscape(api.workspaceID))
 	var result types.Activities
 	var queryParam *types.ActivitiesQuery
 	if len(query) > 0 && query[0] != nil {
@@ -53,7 +54,7 @@ func (api *WorkspacesAPI) GetActivities(ctx context.Context, query ...*types.Act
 }
 
 func (api *WorkspacesAPI) GetWorkspaceMembers(ctx context.Context, query ...*types.WorkspaceMembersQuery) (*types.WorkspaceMembers, error) {
-	path := fmt.Sprintf("/workspaces/%s/members", api.workspaceID)
+	path := fmt.Sprintf("/workspaces/%s/members", url.PathEscape(api.workspaceID))
 	var result types.WorkspaceMembers
 	var queryParam *types.WorkspaceMembersQuery
 	if len(query) > 0 && query[0] != nil {

--- a/test/path_escape_test.go
+++ b/test/path_escape_test.go
@@ -1,0 +1,116 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sdk "github.com/bronlabs/bron-sdk-go/sdk"
+	"github.com/bronlabs/bron-sdk-go/sdk/auth"
+	"github.com/bronlabs/bron-sdk-go/sdk/types"
+)
+
+func newTestClient(srv *httptest.Server, signer func(auth.BronJwtOptions) (string, error)) *sdk.BronClient {
+	return sdk.NewBronClientWithOptions(
+		sdk.BronClientConfig{
+			BaseURL:     srv.URL,
+			WorkspaceID: "ws-test",
+			APIKey:      `{"kid":"dummy"}`,
+		},
+		sdk.WithSigner(signer),
+		sdk.WithClock(func() time.Time { return time.Unix(1700000000, 0) }),
+	)
+}
+
+func dummySigner() func(auth.BronJwtOptions) (string, error) {
+	return func(o auth.BronJwtOptions) (string, error) {
+		return "dummy.jwt.token", nil
+	}
+}
+
+func TestPathEscape_SlashInTransactionId(t *testing.T) {
+	var capturedURI string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURI = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv, dummySigner())
+
+	_, _ = c.Transactions.CancelTransaction(
+		context.Background(),
+		"tx-target/approve?ignored=",
+		types.CancelTransaction{},
+	)
+
+	if !strings.Contains(capturedURI, "%2F") {
+		t.Fatalf("slash in transactionId must be percent-encoded, got URI: %s", capturedURI)
+	}
+
+	if !strings.HasSuffix(strings.SplitN(capturedURI, "?", 2)[0], "/cancel") {
+		t.Fatalf("the /cancel suffix must remain as the final path segment, got URI: %s", capturedURI)
+	}
+
+	if strings.Contains(capturedURI, "/approve") {
+		t.Fatalf("slash must not create a separate /approve path segment, got URI: %s", capturedURI)
+	}
+}
+
+func TestPathEscape_SignerReceivesEscapedPath(t *testing.T) {
+	var signedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv, func(o auth.BronJwtOptions) (string, error) {
+		signedPath = o.Path
+		return "dummy.jwt.token", nil
+	})
+
+	_, _ = c.Transactions.GetTransactionByID(
+		context.Background(),
+		"id/with?special",
+	)
+
+	if !strings.Contains(signedPath, "%2F") {
+		t.Fatalf("slash must be escaped in signed path, got: %s", signedPath)
+	}
+
+	if !strings.Contains(signedPath, "%3F") {
+		t.Fatalf("question mark must be escaped in signed path, got: %s", signedPath)
+	}
+}
+
+func TestPathEscape_NormalIdUnchanged(t *testing.T) {
+	var capturedURI string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURI = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv, dummySigner())
+
+	_, _ = c.Transactions.CancelTransaction(
+		context.Background(),
+		"tx-normal-uuid-1234",
+		types.CancelTransaction{},
+	)
+
+	want := "/workspaces/ws-test/transactions/tx-normal-uuid-1234/cancel"
+	if capturedURI != want {
+		t.Fatalf("normal IDs must pass through unchanged\ngot:  %s\nwant: %s", capturedURI, want)
+	}
+}


### PR DESCRIPTION
Apply url.PathEscape to all dynamic path segments (workspaceID, transactionId, accountId, recordId, balanceId, intentId, limitId, assetId, networkId, symbolId) across all API files to prevent path traversal via crafted IDs containing / or ? characters.

Add httptest-based regression tests verifying slash injection is blocked, JWT signer receives escaped paths, and normal IDs pass through unchanged.

BRO-489